### PR TITLE
As-needed resampling for VADAnalyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ Parameters `input_device_name` and `output_device_name` are accepted; current
 helper uses system defaults. Future releases may wire device selection via
 CoreAudio.
 
+## Run a test bot
+
+```bash
+cd test
+uv run bot.py
+```
+
 ## Roadmap
 - Device selection support
 - Prebuilt universal2 wheels

--- a/src/pipecat_macos_transport/local_mac_transport.py
+++ b/src/pipecat_macos_transport/local_mac_transport.py
@@ -27,8 +27,8 @@ def _is_macos():
 
 
 class LocalMacTransportParams(TransportParams):
-    audio_in_sample_rate: Optional[int] = 48000
-    audio_out_sample_rate: Optional[int] = 48000
+    audio_in_sample_rate: Optional[int] = None
+    audio_out_sample_rate: Optional[int] = None
     audio_in_channels: int = 1
     audio_out_channels: int = 1
     audio_out_10ms_chunks: int = 1
@@ -183,11 +183,12 @@ class MacInputTransport(BaseInputTransport):
 
     async def start(self, frame: StartFrame):
         await super().start(frame)
+        # Determine effective input sample rate from params or StartFrame
+        self._sample_rate = self._params.audio_in_sample_rate or frame.audio_in_sample_rate
         try:
-            await self._parent._ensure_stream_started()
+            await self._parent._ensure_stream_started(self._sample_rate)
         except Exception:
             logger.exception("Error starting VPIO stream for input")
-        self._sample_rate = self._params.audio_in_sample_rate or frame.audio_in_sample_rate
         self._stop = False
         self._poll_task = self.create_task(self._poll_capture())
         await self.set_transport_ready(frame)
@@ -314,8 +315,10 @@ class MacOutputTransport(BaseOutputTransport):
 
     async def start(self, frame: StartFrame):
         await super().start(frame)
+        # Ensure VPIO stream is started with the effective output rate if needed.
         try:
-            await self._parent._ensure_stream_started()
+            out_sr = self._params.audio_out_sample_rate or frame.audio_out_sample_rate
+            await self._parent._ensure_stream_started(out_sr)
         except Exception:
             logger.exception("Error starting VPIO stream for output")
         if self._has_play_thread and self._has_write_10ms:
@@ -652,10 +655,11 @@ class LocalMacTransport(BaseTransport):
             except Exception:
                 logger.exception("Exception in on_client_disconnected handler")
 
-    async def _ensure_stream_started(self):
+    async def _ensure_stream_started(self, sr: Optional[int] = None):
         if self._stream_started:
             return
-        sr = self._params.audio_in_sample_rate or 16000
+        # Prefer explicit argument, else param, else default to 16000
+        sr = sr or self._params.audio_in_sample_rate or 16000
         ch = self._params.audio_in_channels
         cap_bytes = int(
             (self._params.ring_capacity_secs if hasattr(self._params, "ring_capacity_secs") else 2.0)

--- a/src/pipecat_macos_transport/local_mac_transport.py
+++ b/src/pipecat_macos_transport/local_mac_transport.py
@@ -19,6 +19,7 @@ from pipecat.processors.frame_processor import FrameProcessor
 from pipecat.transports.base_input import BaseInputTransport
 from pipecat.transports.base_output import BaseOutputTransport
 from pipecat.transports.base_transport import BaseTransport, TransportParams
+from .vad_resample_adapter import ResamplingVADAdapter
 
 
 def _is_macos():
@@ -26,8 +27,8 @@ def _is_macos():
 
 
 class LocalMacTransportParams(TransportParams):
-    audio_in_sample_rate: Optional[int] = 16000
-    audio_out_sample_rate: Optional[int] = 16000
+    audio_in_sample_rate: Optional[int] = 48000
+    audio_out_sample_rate: Optional[int] = 48000
     audio_in_channels: int = 1
     audio_out_channels: int = 1
     audio_out_10ms_chunks: int = 1
@@ -557,6 +558,15 @@ class LocalMacTransport(BaseTransport):
         super().__init__()
         if not _is_macos():
             raise RuntimeError("LocalMacTransport only supported on macOS")
+        # If a VAD analyzer is provided (e.g., Silero), wrap it to resample only for VAD.
+        try:
+            if getattr(params, "vad_analyzer", None) is not None and not isinstance(
+                params.vad_analyzer, ResamplingVADAdapter
+            ):
+                params.vad_analyzer = ResamplingVADAdapter(params.vad_analyzer, target_rate=16000)
+        except Exception:
+            pass
+
         self._params = params
         self._vpio = _VPIOLib(lib_path)
         logger.info(

--- a/src/pipecat_macos_transport/vad_resample_adapter.py
+++ b/src/pipecat_macos_transport/vad_resample_adapter.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+"""
+Resampling VAD adapter for Mac transport.
+
+This adapter wraps a VADAnalyzer and ensures that, if the analyzer does not
+support the transport's input sample rate (e.g., 48000 Hz), audio is
+resampled to a supported rate (e.g., 16000 Hz) for VAD analysis only.
+
+Pass-through audio remains at the transport rate elsewhere in the pipeline.
+"""
+
+import asyncio
+from typing import Optional
+
+from loguru import logger
+
+from pipecat.audio.utils import create_stream_resampler
+from pipecat.audio.vad.vad_analyzer import VADAnalyzer, VADParams, VADState
+
+
+class ResamplingVADAdapter(VADAnalyzer):
+    """Adapter that resamples audio for the underlying VAD if needed.
+
+    - Attempts to configure the underlying VAD with the transport's sample rate.
+    - If that fails (e.g., Silero requires 8/16 kHz), it configures the VAD at
+      a target rate (default 16 kHz) and resamples incoming audio buffers only
+      for VAD analysis.
+    - Downstream audio frames are unchanged; only VAD input is resampled.
+    """
+
+    def __init__(self, underlying: VADAnalyzer, *, target_rate: int = 16000):
+        # Initialize parent with underlying params for consistency; we do not
+        # use the base class state machine here, delegating to the underlying
+        # analyzer instead.
+        super().__init__(sample_rate=None, params=underlying.params)
+        self._underlying = underlying
+        self._target_rate = target_rate
+        self._transport_sr: int = 0
+        self._resample_needed: bool = False
+        self._resampler = create_stream_resampler()
+
+    # Properties delegate to underlying so control frames report real values
+    @property
+    def params(self) -> VADParams:  # type: ignore[override]
+        return self._underlying.params
+
+    @property
+    def sample_rate(self) -> int:  # type: ignore[override]
+        # Report the underlying analyzer's configured sample rate.
+        return self._underlying.sample_rate
+
+    def set_sample_rate(self, sample_rate: int):  # type: ignore[override]
+        """Try to set underlying VAD to transport SR, else fall back to target SR."""
+        self._transport_sr = sample_rate
+        try:
+            # If the underlying analyzer supports this SR, use it directly.
+            self._underlying.set_sample_rate(sample_rate)
+            self._resample_needed = False
+            logger.debug(
+                f"VAD adapter using native SR {sample_rate} Hz (no resampling)."
+            )
+        except Exception as e:
+            # Fallback to target rate (e.g., 16kHz for Silero)
+            logger.debug(
+                f"Underlying VAD rejected SR {sample_rate} Hz ({e}); using {self._target_rate} Hz with resampling."
+            )
+            self._underlying.set_sample_rate(self._target_rate)
+            self._resample_needed = True
+
+    def set_params(self, params: VADParams):  # type: ignore[override]
+        # Forward updated params to the underlying analyzer
+        self._underlying.set_params(params)
+
+    def num_frames_required(self) -> int:  # type: ignore[override]
+        # Delegate to underlying analyzer
+        return self._underlying.num_frames_required()
+
+    def voice_confidence(self, buffer) -> float:  # type: ignore[override]
+        # Not used when we delegate analyze_audio; still delegate for completeness
+        return self._underlying.voice_confidence(buffer)
+
+    def _resample_sync(self, audio: bytes, in_rate: int, out_rate: int) -> bytes:
+        """Synchronously resample audio using the stream resampler.
+
+        This runs the async resampler in a private event loop within the
+        executor thread used by BaseInputTransport.
+        """
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                asyncio.set_event_loop(loop)
+                return loop.run_until_complete(
+                    self._resampler.resample(audio, in_rate, out_rate)
+                )
+            finally:
+                try:
+                    loop.close()
+                except Exception:
+                    pass
+        except Exception as e:
+            logger.exception(f"VAD adapter resample failed: {e}")
+            # On failure, return original audio to avoid crashing
+            return audio
+
+    def analyze_audio(self, buffer) -> VADState:  # type: ignore[override]
+        # Optionally resample to the underlying analyzer's configured rate
+        if self._resample_needed and self._transport_sr and self._target_rate:
+            buffer = self._resample_sync(buffer, self._transport_sr, self._target_rate)
+        # Delegate state machine and confidence calculation to the underlying analyzer
+        return self._underlying.analyze_audio(buffer)
+

--- a/test/bot.py
+++ b/test/bot.py
@@ -1,0 +1,168 @@
+import asyncio
+import os
+from datetime import datetime
+
+from dotenv import load_dotenv
+from loguru import logger
+
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.runner import PipelineRunner
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
+from pipecat.runner.types import RunnerArguments
+from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.transports.base_transport import BaseTransport
+from pipecat.services.deepgram.stt import DeepgramSTTService
+from pipecat.services.cartesia.tts import CartesiaTTSService
+from pipecat.frames.frames import LLMRunFrame, LLMMessagesAppendFrame
+from pipecat.processors.frame_processor import FrameDirection
+from pipecat.processors.frameworks.rtvi import (
+    RTVIConfig,
+    RTVIObserver,
+    RTVIProcessor,
+    RTVIUserTranscriptionMessage,
+    BotInterruptionFrame,
+)
+from pipecat.frames.frames import StartFrame, StopFrame
+from pipecat_macos_transport.local_mac_transport import (
+    LocalMacTransport,
+    LocalMacTransportParams,
+)
+
+load_dotenv(override=True)
+
+
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
+    stt = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))
+
+    llm = OpenAILLMService(
+        api_key=os.getenv("OPENAI_API_KEY"),
+        model="gpt-4.1",
+    )
+
+    tts = CartesiaTTSService(
+        api_key=os.getenv("CARTESIA_API_KEY"),
+        voice_id="71a7ad14-091c-4e8e-a314-022ece01c121",  # British Reading Lady
+    )
+
+    rtvi = RTVIProcessor(config=RTVIConfig(config=[]))
+    rtvi_observer = RTVIObserver(rtvi)
+
+    # System message that instructs the AI on how to speak
+    messages = [
+        {
+            "role": "system",
+            "content": """You are a helpful assistant. Respond to what the user said in a creative and helpful way.""",
+        },
+    ]
+
+    context = OpenAILLMContext(messages)
+    context_aggregator = llm.create_context_aggregator(context)
+
+    pipeline = Pipeline(
+        [
+            transport.input(),  # Transport user input
+            rtvi,
+            stt,  # STT
+            context_aggregator.user(),  # User responses
+            llm,  # LLM
+            tts,  # Gemini TTS
+            transport.output(),  # Transport bot output
+            context_aggregator.assistant(),  # Assistant spoken responses
+        ]
+    )
+
+    task = PipelineTask(
+        pipeline,
+        params=PipelineParams(
+            audio_in_sample_rate=48000,
+            audio_out_sample_rate=48000,
+            enable_metrics=True,
+            enable_usage_metrics=True,
+        ),
+        observers=[rtvi_observer],
+        idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
+    )
+
+    @transport.event_handler("on_client_connected")
+    async def on_client_connected(transport, client):
+        await rtvi.set_bot_ready()
+        await task.queue_frames([LLMRunFrame()])
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        await task.cancel()
+
+    @rtvi.event_handler("on_client_message")
+    async def on_client_message(rtvi, message):
+        # called for rtvi-ai messages of type "client-message"
+        logger.info(f"!!! Client message: {message}")
+        # New style: typed client messages surfaced via RTVI as message.type
+        if getattr(message, "type", None) == "mute-unmute":
+            try:
+                mute = bool(getattr(message, "data", {}).get("mute"))
+                if mute:
+                    await transport.input().process_frame(StopFrame(), FrameDirection.DOWNSTREAM)
+                    logger.info("Input muted via client-message (typed)")
+                else:
+                    await transport.input().process_frame(StartFrame(), FrameDirection.DOWNSTREAM)
+                    logger.info("Input unmuted via client-message (typed)")
+            except Exception:
+                logger.exception("Failed to toggle mute from client-message (typed)")
+        elif message.type == "llm-input":
+            # Two shapes supported:
+            # 1) { messages: [...] } for direct LLM message injection
+            # 2) { type: "mute-unmute", mute: true|false } for input control
+            d = message.data or {}
+            if isinstance(d, dict) and d.get("type") == "mute-unmute":
+                try:
+                    mute = bool(d.get("mute"))
+                    if mute:
+                        await transport.input().process_frame(
+                            StopFrame(), FrameDirection.DOWNSTREAM
+                        )
+                        logger.info("Input muted via client-message")
+                    else:
+                        await transport.input().process_frame(
+                            StartFrame(), FrameDirection.DOWNSTREAM
+                        )
+                        logger.info("Input unmuted via client-message")
+                except Exception:
+                    logger.exception("Failed to toggle mute from client-message")
+            else:
+                messages = d.get("messages", [])
+                if len(messages) > 0:
+                    text = messages[0].get("content", "")
+                    await rtvi_observer.push_transport_message_urgent(
+                        RTVIUserTranscriptionMessage(
+                            data={
+                                "text": text,
+                                "user_id": "",
+                                "timestamp": str(datetime.now()),
+                                "final": True,
+                            }
+                        )
+                    )
+                    await task.queue_frames(
+                        [
+                            BotInterruptionFrame(),
+                            LLMMessagesAppendFrame(messages=messages, run_llm=True),
+                        ]
+                    )
+
+    runner = PipelineRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.run(task)
+
+
+if __name__ == "__main__":
+    logger.info("Using new AEC transport")
+
+    params = LocalMacTransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+        vad_analyzer=SileroVADAnalyzer(),
+    )
+    transport = LocalMacTransport(params=params)
+    asyncio.run(run_bot(transport, RunnerArguments()))

--- a/test/pyproject.toml
+++ b/test/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "pipecat-macos-transport-smoke"
+version = "0.0.0"
+description = "Smoke test for LocalMacTransport bot"
+requires-python = ">=3.12,<3.13"
+dependencies = [
+  "pipecat-ai[silero,deepgram,openai,cartesia]==0.0.84",
+  "pipecat-ai-macos-transport",  # local package (path specified below)
+  "python-dotenv>=1.0",
+  "loguru>=0.7",
+  "fastapi>=0.110",
+  "websockets>=12",
+]
+
+[tool.uv]
+package = true
+
+[tool.uv.sources]
+pipecat-ai-macos-transport = { path = "..", editable = true }


### PR DESCRIPTION
Added a new `ResamplingVADAdapter` that wraps the transport `VADAnalyzer` and resamples to a target rate if necessary.

With this change, we can set the Pipeline input and output sample rates to 48khz for maximum efficiency and audio quality on macOS.

```
    task = PipelineTask(
        pipeline,
        params=PipelineParams(
            audio_in_sample_rate=48000,
            audio_out_sample_rate=48000,
            enable_metrics=True,
            enable_usage_metrics=True,
        ),
        observers=[rtvi_observer],
        idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
    )
```